### PR TITLE
Fix installation with catkin_make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,28 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(livox_laser_simulation)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
+  gazebo_ros
   roscpp
   tf
   livox_ros_driver
 )
 
+## Find gazebo
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
 find_package(gazebo REQUIRED)
 find_package(PCL REQUIRED)
-include_directories(${GAZEBO_INCLUDE_DIRS})
-
-
-#To solve the error which gazebo does not handle the include file well, we must add this line.
-include_directories(/usr/include/gazebo-7/gazebo)
-
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
-#This is designed for whose proto installed in system is not 2.6. We can install the version of proto in local dir
-#include_directories(/home/lfc/proto/include/)
-#link_directories(/home/lfc/proto/lib/)
-
 include_directories(
-         include
+        include
         ${catkin_INCLUDE_DIRS}
         ${PCL_INCLUDE_DIRS}
+        ${GAZEBO_INCLUDE_DIRS}
 )
 
 catkin_package(
@@ -37,6 +32,27 @@ catkin_package(
 )
 
 add_library(livox_laser_simulation SHARED src/livox_points_plugin.cpp src/livox_ode_multiray_shape.cpp)
-target_link_libraries(livox_laser_simulation ${catkin_LIBRARIES} RayPlugin)
+target_link_libraries(livox_laser_simulation ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} RayPlugin)
 
-target_link_libraries(livox_laser_simulation libprotobuf.so.9)
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+    FILES_MATCHING PATTERN "*.h"
+    PATTERN ".svn" EXCLUDE
+)
+
+install(TARGETS livox_laser_simulation
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY
+        launch
+        meshes
+        resources
+        rviz
+        scan_mode
+        urdf
+        worlds
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(livox_laser_simulation)
 
-add_compile_options(-std=c++17)
+# C++ configs.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
@@ -14,8 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
 if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
-find_package(gazebo REQUIRED)
-find_package(PCL REQUIRED)
+find_package(gazebo 9 REQUIRED)
+find_package(PCL 1.12 REQUIRED)
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
 include_directories(
@@ -36,8 +39,6 @@ target_link_libraries(livox_laser_simulation ${catkin_LIBRARIES} ${GAZEBO_LIBRAR
 
 install(DIRECTORY include/${PROJECT_NAME}/
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-    FILES_MATCHING PATTERN "*.h"
-    PATTERN ".svn" EXCLUDE
 )
 
 install(TARGETS livox_laser_simulation

--- a/README.md
+++ b/README.md
@@ -11,17 +11,14 @@ A package to provide plug-in for [Livox Series LiDAR](https://www.livoxtech.com)
 ## Branchs
 
 ### main branch
-- enviroment: ROS kinetic + gazebo7
-- pointcloud type: 
+- enviroment: ROS Melodic + Gazebo 9
+- pointcloud type:
   - sensor_msg::pointcloud
-  - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZ\>)
+  - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZI\>)
   - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::LivoxPointXyzrtl\>)
   - livox_ros_driver::CustomMsg
-  <!-- - livox_ros_driver::CustomMsg -->
 
-### gazebo9
-- enviroment: ROS melodic + gazebo7
-- pointcloud type: sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZ\>)
+
 
 ## Dependence
 
@@ -35,7 +32,7 @@ Before you write your urdf file by using this plugin, catkin_make/catkin build i
 
 A simple demo is shown in livox_simulation.launch
 
-Run 
+Run
 ```
     roslauch livox_laser_simulation livox_simulation.launch
 ```
@@ -53,7 +50,7 @@ Change sensor by change the following lines in the robot.xacro into another xacr
 - mid70.csv
 - tele.csv
 
-## Parameters(example by avia)
+## Parameters(example by Avia)
 
 - laser_min_range: 0.1  // min detection range
 - laser_max_range: 200.0  // max detection range
@@ -62,7 +59,7 @@ Change sensor by change the following lines in the robot.xacro into another xacr
 - ros_topic: scan // topic in ros
 - samples: 24000  // number of points in each scan loop
 - downsample: 1 // we can increment this para to decrease the consumption
-- publish_pointcloud_type: 0 // 0 for sensor_msgs::PointCloud, 1 for sensor_msgs::Pointcloud2(PointXYZ), 2 for sensor_msgs::PointCloud2(LivoxPointXyzrtl) 3 for livox_ros_driver::CustomMsg.
+- publish_pointcloud_type: 0 // 0 for sensor_msgs::PointCloud, 1 for sensor_msgs::Pointcloud2(PointXYZI), 2 for sensor_msgs::PointCloud2(LivoxPointXyzrtl) 3 for livox_ros_driver::CustomMsg.
 
 ## Simulation for mapping
 Currently [Fast-LIO](https://github.com/hku-mars/FAST_LIO) is tested when publish_pointcloud_type = 3。

--- a/include/livox_laser_simulation/livox_point_xyzrtl.h
+++ b/include/livox_laser_simulation/livox_point_xyzrtl.h
@@ -1,5 +1,5 @@
 
-  
+
 /*
  * Created on Sun Aug 15 2021
  *
@@ -26,7 +26,7 @@ struct LivoxPointXyzrtl{
 
 }
 
-POINT_CLOUD_REGISTER_POINT_STRUCT (LivoxPointXyzrtl,  
+POINT_CLOUD_REGISTER_POINT_STRUCT (LivoxPointXyzrtl,
                                    (float, x, x)
                                    (float, y, y)
                                    (float, z, z)

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -20,9 +20,9 @@ struct AviaRotateInfo {
 
 class LivoxPointsPlugin : public RayPlugin {
  public:
-    LivoxPointsPlugin();
+    LivoxPointsPlugin() = default;
 
-    virtual ~LivoxPointsPlugin();
+    virtual ~LivoxPointsPlugin() = default;
 
     void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
 
@@ -107,6 +107,8 @@ class LivoxPointsPlugin : public RayPlugin {
     std::shared_ptr<ros::NodeHandle> rosNode;
     ros::Publisher rosPointPub;
     std::shared_ptr<tf::TransformBroadcaster> tfBroadcaster;
+
+    std::string namespace_{""};
 
     int64_t samplesStep = 0;
     int64_t currStartIndex = 0;

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -77,7 +77,7 @@ class LivoxPointsPlugin : public RayPlugin {
  private:
     enum PointCloudType {
         SENSOR_MSG_POINT_CLOUD = 0,
-        SENSOR_MSG_POINT_CLOUD2_POINTXYZ = 1,
+        SENSOR_MSG_POINT_CLOUD2_POINTXYZI = 1,
         SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL = 2,
         LIVOX_ROS_DRIVER_CUSTOM_MSG = 3,
     };
@@ -90,7 +90,7 @@ class LivoxPointsPlugin : public RayPlugin {
     void SendRosTf(const ignition::math::Pose3d& pose, const std::string& father_frame, const std::string& child_frame);
 
     void PublishPointCloud(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
-    void PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
+    void PublishPointCloud2XYZI(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
     void PublishPointCloud2XYZRTL(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
     void PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
 

--- a/package.xml
+++ b/package.xml
@@ -1,63 +1,24 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>livox_laser_simulation</name>
   <version>0.0.0</version>
   <description>The livox_laser_simulation package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="lfc@todo.todo">lfc</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>TODO</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/livox_laser_simulation</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>tf</build_depend>
+
+  <build_depend>gazebo</build_depend>
+  <build_depend>gazebo_ros</build_depend>
   <build_depend>livox_ros_driver</build_depend>
+  <build_depend>tf</build_depend>
+
   <build_export_depend>tf</build_export_depend>
+
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>tf</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -57,8 +57,7 @@ void LivoxOdeMultiRayShape::UpdateRays()
     ODEPhysicsPtr ode = boost::dynamic_pointer_cast<ODEPhysics>(
         this->GetWorld()->Physics());
 
-    if (ode == NULL)
-        gzthrow("Invalid physics engine. Must use ODE.");
+    GZ_ASSERT(ode, "Invalid physics engine. Must use ODE.");
 
     // Do we need to lock the physics engine here? YES!
     // especially when spawning models with sensors
@@ -122,7 +121,7 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
         ODECollision *hitCollision = NULL;
 
         // Figure out which one is a ray; note that this assumes
-        // that the ODE dRayClass is used *soley* by the RayCollision.
+        // that the ODE dRayClass is used *solely* by the RayCollision.
         if (dGeomGetClass(_o1) == dRayClass)
         {
             rayCollision = static_cast<ODECollision*>(collision1);
@@ -142,7 +141,7 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
         // Check for ray/collision intersections
         if (rayCollision && hitCollision)
         {
-            int n = dCollide(_o1, _o2, 1, &contact, sizeof(contact));
+            const int n = dCollide(_o1, _o2, 1, &contact, sizeof(contact));
 
             if (n > 0)
             {
@@ -150,17 +149,6 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
                     rayCollision->GetShape());
                 if (contact.depth < shape->GetLength())
                 {
-                    // gzerr << "LivoxOdeMultiRayShape UpdateCallback dSpaceCollide2 "
-                    //      << " depth[" << contact.depth << "]"
-                    //      << " position[" << contact.pos[0]
-                    //        << ", " << contact.pos[1]
-                    //        << ", " << contact.pos[2]
-                    //        << ", " << "]"
-                    //      << " ray[" << rayCollision->GetScopedName() << "]"
-                    //      << " pose[" << rayCollision->GetWorldPose() << "]"
-                    //      << " hit[" << hitCollision->GetScopedName() << "]"
-                    //      << " pose[" << hitCollision->GetWorldPose() << "]"
-                    //      << "\n";
                     shape->SetLength(contact.depth);
                     shape->SetRetro(hitCollision->GetLaserRetro());
                 }

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -7,6 +7,7 @@
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/PointCloud.h>
+#include <ignition/math/Vector3.hh>
 #include <gazebo/physics/Model.hh>
 #include <gazebo/physics/MultiRayShape.hh>
 #include <gazebo/physics/PhysicsEngine.hh>
@@ -93,7 +94,7 @@ void LivoxPointsPlugin::Load(gazebo::sensors::SensorPtr _parent, sdf::ElementPtr
     ROS_INFO_STREAM("sample:" << samplesStep);
     ROS_INFO_STREAM("downsample:" << downSample);
 
-    publishPointCloudType = sdfPtr->Get<uint16_t>("publish_pointcloud_type");
+    publishPointCloudType = sdfPtr->Get<int>("publish_pointcloud_type");
     ROS_INFO_STREAM("publish_pointcloud_type: " << publishPointCloudType);
     ros::init(argc, argv, curr_scan_topic);
     rosNode.reset(new ros::NodeHandle);
@@ -124,10 +125,10 @@ void LivoxPointsPlugin::Load(gazebo::sensors::SensorPtr _parent, sdf::ElementPtr
     for (int j = 0; j < samplesStep; j += downSample) {
         int index = j % maxPointSize;
         auto &rotate_info = aviaInfos[index];
-        ignition::math::Quaterniond ray;
+        ignition::math::Quaternion<double> ray;
         ray.Euler(ignition::math::Vector3d(0.0, rotate_info.zenith, rotate_info.azimuth));
         auto axis = offset.Rot() * ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
-        start_point = minDist * axis + offset.Pos();
+        start_point = offset.Pos();
         end_point = maxDist * axis + offset.Pos();
         rayShape->AddRay(start_point, end_point);
     }
@@ -176,7 +177,7 @@ void LivoxPointsPlugin::InitializeRays(std::vector<std::pair<int, AviaRotateInfo
         auto &rotate_info = aviaInfos[index];
         ray.Euler(ignition::math::Vector3d(0.0, rotate_info.zenith, rotate_info.azimuth));
         auto axis = offset.Rot() * ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
-        start_point = minDist * axis + offset.Pos();
+        start_point = offset.Pos();
         end_point = maxDist * axis + offset.Pos();
         if (ray_index < ray_size) {
             rays[ray_index]->SetPoints(start_point, end_point);

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -94,14 +94,14 @@ void LivoxPointsPlugin::Load(gazebo::sensors::SensorPtr _parent, sdf::ElementPtr
     ROS_INFO_STREAM("downsample:" << downSample);
 
     publishPointCloudType = sdfPtr->Get<uint16_t>("publish_pointcloud_type");
-    ROS_WARN_STREAM("publish_pointcloud_type: " << publishPointCloudType);
+    ROS_INFO_STREAM("publish_pointcloud_type: " << publishPointCloudType);
     ros::init(argc, argv, curr_scan_topic);
     rosNode.reset(new ros::NodeHandle);
     switch (publishPointCloudType) {
         case SENSOR_MSG_POINT_CLOUD:
             rosPointPub = rosNode->advertise<sensor_msgs::PointCloud>(curr_scan_topic, 5);
             break;
-        case SENSOR_MSG_POINT_CLOUD2_POINTXYZ:
+        case SENSOR_MSG_POINT_CLOUD2_POINTXYZI:
         case SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL:
             rosPointPub = rosNode->advertise<sensor_msgs::PointCloud2>(curr_scan_topic, 5);
             break;
@@ -145,8 +145,8 @@ void LivoxPointsPlugin::OnNewLaserScans() {
             case SENSOR_MSG_POINT_CLOUD:
                 PublishPointCloud(points_pair);
                 break;
-            case SENSOR_MSG_POINT_CLOUD2_POINTXYZ:
-                PublishPointCloud2XYZ(points_pair);
+            case SENSOR_MSG_POINT_CLOUD2_POINTXYZI:
+                PublishPointCloud2XYZI(points_pair);
                 break;
             case SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL:
                 PublishPointCloud2XYZRTL(points_pair);
@@ -383,7 +383,7 @@ void LivoxPointsPlugin::PublishPointCloud(std::vector<std::pair<int, AviaRotateI
     }
 }
 
-void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRotateInfo>> &points_pair) {
+void LivoxPointsPlugin::PublishPointCloud2XYZI(std::vector<std::pair<int, AviaRotateInfo>> &points_pair) {
     auto rayCount = RayCount();
     auto verticalRayCount = VerticalRayCount();
     auto angle_min = AngleMin().Radian();
@@ -396,7 +396,7 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
 
     sensor_msgs::PointCloud2 scan_point;
 
-    pcl::PointCloud<pcl::PointXYZ> pc;
+    pcl::PointCloud<pcl::PointXYZI> pc;
     pc.points.resize(points_pair.size());
     ros::Time timestamp = ros::Time::now();
     int pt_count = 0;
@@ -409,9 +409,9 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
             continue;
         }
         if (verticle_index < verticalRayCount && horizon_index < rayCount) {
-            auto index = (verticalRayCount - verticle_index - 1) * rayCount + horizon_index;
-            auto range = rayShape->GetRange(pair.first);
-            auto intensity = rayShape->GetRetro(pair.first);
+            const auto index = (verticalRayCount - verticle_index - 1) * rayCount + horizon_index;
+            const auto range = rayShape->GetRange(pair.first);
+            const auto intensity = rayShape->GetRetro(pair.first);
             if (range >= RangeMax() || range <= RangeMin() || range < 0.1) continue;
 
             scan->set_ranges(index, range);
@@ -420,20 +420,14 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
             auto rotate_info = pair.second;
             ignition::math::Quaterniond ray;
             ray.Euler(ignition::math::Vector3d(0.0, rotate_info.zenith, rotate_info.azimuth));
-            //                auto axis = rotate * ray * math::Vector3(1.0, 0.0, 0.0);
-            //                auto point = range * axis + world_pose.Pos();//转换成世界坐标系
-
             auto axis = ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
-
-            // if (range < 0.3) {
-            //     ROS_WARN_STREAM("Small pt: range: " << range << ", axis: " << axis);
-            // }
             auto point = range * axis;
-            pcl::PointXYZ pt;
+
+            pcl::PointXYZI pt;
             pt.x = point.X();
             pt.y = point.Y();
             pt.z = point.Z();
-            // if (pt_count < pc.size() && pt_count > 0)
+            pt.intensity = static_cast<float>(intensity);
 #pragma omp critical
             {
                 pc[pt_count] = pt;
@@ -446,7 +440,6 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
     scan_point.header.stamp = timestamp;
     scan_point.header.frame_id = "livox";
     rosPointPub.publish(scan_point);
-    // SendRosTf(parentEntity->WorldPose(), world->Name(), raySensor->ParentName());
     ros::spinOnce();
     if (scanPub && scanPub->HasConnections() && visualize) {
         scanPub->Publish(laserMsg);
@@ -534,7 +527,7 @@ void LivoxPointsPlugin::PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int
 
     msg.header.frame_id = "livox";
 
-    struct timespec tn; 
+    struct timespec tn;
     clock_gettime(CLOCK_REALTIME, &tn);
 
     msg.timebase = tn.tv_nsec;
@@ -565,15 +558,13 @@ void LivoxPointsPlugin::PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int
 
             auto axis = ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
             auto point = range * axis;
-            // pt.reflectivity = static_cast<float>(intensity);
             livox_ros_driver::CustomPoint pt;
             pt.x = point.X();
             pt.y = point.Y();
             pt.z = point.Z();
-            pt.line = pair.second.line;
-            // ROS_INFO_STREAM("offset_time: " << pt.offset_time );
-            pt.tag = 0x10;
             pt.reflectivity = 100;
+            pt.line = pair.second.line;
+            pt.tag = 0x10;
             msg.points.push_back(pt);
         }
     }

--- a/urdf/livox_avia.xacro
+++ b/urdf/livox_avia.xacro
@@ -1,34 +1,31 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	
-  <xacro:property name="M_PI" value="3.14159"/> 
+
   <xacro:property name="laser_min_range" value="0.1"/>
   <xacro:property name="laser_max_range" value="200.0"/>
   <xacro:property name="horizontal_fov" value="70.4"/>
   <xacro:property name="vertical_fov" value="77.2"/>
   <xacro:property name="ros_topic" value="scan"/>
   <xacro:property name="samples" value="24000"/>
-  <xacro:property name="downsample" value="1"/>
+  <xacro:property name="publish_pointcloud_type" value="0"/>
   <xacro:property name="csv_file_name" value="package://livox_laser_simulation/scan_mode/avia.csv"/>
-  
+
   <xacro:include filename="$(find livox_laser_simulation)/urdf/livox_gazebo_sensor.xacro"/>
-  <xacro:macro name="Livox_Avia" params="visualize:=True name:=livox publish_pointcloud_type:=0">
+  <xacro:macro name="Livox_Avia" params="visualize:=True name:=livox publish_pointcloud_type:=0
+                                         ros_topic:=livox/lidar downsample:=1
+                                         noise_mean:=0.0 noise_stddev:=0.01 imu_noise_stddev:=0.00264">
     <link name="${name}_base">
       <xacro:null_inertial/>
-      <visual> 
-        <origin xyz="0.00 0 0.00" rpy="0 0 0"/>
+      <visual>
         <geometry>
-          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
-          </mesh>
+          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae"/>
         </geometry>
       </visual>
 
       <collision>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <geometry>
-          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
-          </mesh>
-          </geometry>
+        <geometry>
+          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae"/>
+        </geometry>
       </collision>
     </link>
     <link name="${name}">
@@ -38,8 +35,18 @@
     <joint name="${name}_to_${name}_base_joint" type="fixed">
       <parent link="${name}_base"/>
       <child link="${name}"/>
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
     </joint>
-    <xacro:Livox_gazebo_sensor name="${name}" visualize="${visualize}" publish_pointcloud_type="${publish_pointcloud_type}"/>
+
+    <link name="${name}_imu_link"/>
+
+    <!-- IMU Coordinates: https://terra-1-g.djicdn.com/65c028cd298f4669a7f0e40e50ba1131/demo/avia/Livox%20AVIA%20User%20Manual_EN.pdf -->
+    <joint name="imu_link_joint" type="fixed">
+      <parent link="${name}"/>
+      <child link="${name}_imu_link"/>
+      <origin xyz="-0.04165 -0.02326 0.0284"/>
+    </joint>
+
+    <xacro:Livox_gazebo_sensor name="${name}" visualize="${visualize}" publish_pointcloud_type="${publish_pointcloud_type}"
+                               noise_mean="${noise_mean}" noise_stddev="${noise_stddev}" imu_noise_stddev="${imu_noise_stddev}"/>
   </xacro:macro>
 </robot>

--- a/urdf/livox_gazebo_sensor.xacro
+++ b/urdf/livox_gazebo_sensor.xacro
@@ -3,9 +3,9 @@
   <xacro:macro name="null_inertial">
     <inertial>
       <mass value="0.1"/>
-    <inertia ixx="0.001" ixy="0" ixz="0"
-          iyy="0.001" iyz="0"
-          izz="0.001"/>
+      <inertia ixx="0.001" ixy="0" ixz="0"
+               iyy="0.001" iyz="0"
+               izz="0.001"/>
     </inertial>
   </xacro:macro>
   <xacro:macro name="Livox_gazebo_sensor"
@@ -50,6 +50,7 @@
           <csv_file_name>${csv_file_name}</csv_file_name>
           <publish_pointcloud_type>${publish_pointcloud_type}</publish_pointcloud_type>
           <ros_topic>${ros_topic}</ros_topic>
+          <robotNamespace>livox</robotNamespace>
         </plugin>
       </sensor>
       <sensor name="livox_imu" type="imu">
@@ -58,7 +59,8 @@
         <update_rate>200</update_rate>
         <visualize>false</visualize>
         <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
-          <topicName>/livox/imu</topicName>
+          <robotNamespace>livox</robotNamespace>
+          <topicName>imu</topicName>
           <bodyName>livox_imu_link</bodyName>
           <updateRateHZ>200.0</updateRateHZ>
           <xyzOffset>0 0 0</xyzOffset>

--- a/urdf/livox_gazebo_sensor.xacro
+++ b/urdf/livox_gazebo_sensor.xacro
@@ -8,7 +8,10 @@
           izz="0.001"/>
     </inertial>
   </xacro:macro>
-  <xacro:macro name="Livox_gazebo_sensor" params="visualize:=True update_rate:=10 resolution:=0.002 noise_mean:=0.0 noise_stddev:=0.01 name:=livox publish_pointcloud_type:=1">
+  <xacro:macro name="Livox_gazebo_sensor"
+               params="visualize:=True update_rate:=10 resolution:=0.002
+                       noise_mean:=0.0 noise_stddev:=0.01 imu_noise_stddev:=0.0026399240948208127
+                       name:=livox publish_pointcloud_type:=1">
     <gazebo reference="${name}">
       <sensor type="ray" name="livox_lidar">
         <pose>0 0 0 0 0 0</pose>
@@ -20,14 +23,14 @@
             <horizontal>
             <samples>100</samples>
             <resolution>1</resolution>
-            <min_angle>${-horizontal_fov/360*M_PI}</min_angle>
-            <max_angle>${horizontal_fov/360*M_PI}</max_angle>
+            <min_angle>${-horizontal_fov/360*pi}</min_angle>
+            <max_angle>${horizontal_fov/360*pi}</max_angle>
             </horizontal>
             <vertical>
             <samples>50</samples>
             <resolution>1</resolution>
-            <min_angle>${-vertical_fov/360*M_PI}</min_angle>
-            <max_angle>${vertical_fov/360*M_PI}</max_angle>
+            <min_angle>${-vertical_fov/360*pi}</min_angle>
+            <max_angle>${vertical_fov/360*pi}</max_angle>
             </vertical>
             </scan>
             <range>
@@ -50,22 +53,20 @@
         </plugin>
       </sensor>
       <sensor name="livox_imu" type="imu">
+        <pose>0 0 0 0 0 0</pose>
         <always_on>true</always_on>
         <update_rate>200</update_rate>
         <visualize>false</visualize>
-        <topic>"/livox/imu"</topic>
         <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
           <topicName>/livox/imu</topicName>
           <bodyName>livox_imu_link</bodyName>
           <updateRateHZ>200.0</updateRateHZ>
           <xyzOffset>0 0 0</xyzOffset>
-          <!-- <gaussianNoise>0.0026399240948208127</gaussianNoise> -->
-          <gaussianNoise>0.00</gaussianNoise>
+          <gaussianNoise>${imu_noise_stddev}</gaussianNoise>
           <rpyOffset>0 0 0</rpyOffset>
           <frameName>livox_imu_link</frameName>
           <initialOrientationAsReference>false</initialOrientationAsReference>
         </plugin>
-        <pose>0 0 0 0 0 0</pose>
       </sensor>
     </gazebo>
   </xacro:macro>

--- a/urdf/livox_horizon.xacro
+++ b/urdf/livox_horizon.xacro
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:property name="M_PI" value="3.14159"/>
   <xacro:property name="laser_min_range" value="0.1"/>
   <xacro:property name="laser_max_range" value="200.0"/>
   <xacro:property name="horizontal_fov" value="81.7"/>
@@ -12,23 +11,20 @@
   <xacro:property name="csv_file_name" value="package://livox_laser_simulation/scan_mode/horizon.csv"/>
 
   <xacro:include filename="$(find livox_laser_simulation)/urdf/livox_gazebo_sensor.xacro"/>
-  <xacro:macro name="Livox_Horizon" params="visualize:=True name:=livox publish_pointcloud_type:=0 ros_topic:=livox/lidar downsample:=1
-                                            noise_mean:=0.0 noise_stddev:=0.01 imu_noise_stddev:=0.0026399240948208127">
+  <xacro:macro name="Livox_Horizon" params="visualize:=True name:=livox publish_pointcloud_type:=0
+                                            ros_topic:=livox/lidar downsample:=1
+                                            noise_mean:=0.0 noise_stddev:=0.01 imu_noise_stddev:=0.00264">
     <link name="${name}_base">
       <xacro:null_inertial/>
       <visual>
-        <origin xyz="0.00 0 0.00" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
-          </mesh>
+          <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae"/>
         </geometry>
       </visual>
 
       <collision>
-		  <origin xyz="0.00 0 0.00" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
-		    </mesh>
+        <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae"/>
       </geometry>
       </collision>
     </link>
@@ -39,7 +35,6 @@
     <joint name="${name}_to_${name}_base_joint" type="fixed">
       <parent link="${name}_base"/>
       <child link="${name}"/>
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
     </joint>
 
     <link name="${name}_imu_link"/>
@@ -47,7 +42,7 @@
     <joint name="imu_link_joint" type="fixed">
       <parent link="${name}"/>
       <child link="${name}_imu_link"/>
-      <origin rpy="0 0 0" xyz="-0.05512 -0.02226 0.0297"/>
+      <origin xyz="-0.05512 -0.02226 0.0297"/>
     </joint>
 
     <xacro:Livox_gazebo_sensor name="${name}" visualize="${visualize}" publish_pointcloud_type="${publish_pointcloud_type}"

--- a/urdf/livox_horizon.xacro
+++ b/urdf/livox_horizon.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:property name="M_PI" value="3.14159"/> 
+  <xacro:property name="M_PI" value="3.14159"/>
   <xacro:property name="laser_min_range" value="0.1"/>
   <xacro:property name="laser_max_range" value="200.0"/>
   <xacro:property name="horizontal_fov" value="81.7"/>
@@ -12,10 +12,11 @@
   <xacro:property name="csv_file_name" value="package://livox_laser_simulation/scan_mode/horizon.csv"/>
 
   <xacro:include filename="$(find livox_laser_simulation)/urdf/livox_gazebo_sensor.xacro"/>
-  <xacro:macro name="Livox_Horizon" params="visualize:=True name:=livox publish_pointcloud_type:=0 ros_topic:=livox/lidar downsample:=1">
+  <xacro:macro name="Livox_Horizon" params="visualize:=True name:=livox publish_pointcloud_type:=0 ros_topic:=livox/lidar downsample:=1
+                                            noise_mean:=0.0 noise_stddev:=0.01 imu_noise_stddev:=0.0026399240948208127">
     <link name="${name}_base">
       <xacro:null_inertial/>
-      <visual> 
+      <visual>
         <origin xyz="0.00 0 0.00" rpy="0 0 0"/>
         <geometry>
           <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
@@ -26,7 +27,7 @@
       <collision>
 		  <origin xyz="0.00 0 0.00" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae"> 
+        <mesh filename="package://livox_laser_simulation/meshes/livox_mid40.dae">
 		    </mesh>
       </geometry>
       </collision>
@@ -49,6 +50,7 @@
       <origin rpy="0 0 0" xyz="-0.05512 -0.02226 0.0297"/>
     </joint>
 
-    <xacro:Livox_gazebo_sensor name="${name}" visualize="${visualize}" publish_pointcloud_type="${publish_pointcloud_type}"/>
+    <xacro:Livox_gazebo_sensor name="${name}" visualize="${visualize}" publish_pointcloud_type="${publish_pointcloud_type}"
+                               noise_mean="${noise_mean}" noise_stddev="${noise_stddev}" imu_noise_stddev="${imu_noise_stddev}"/>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
The package does not install some resources properly hence the command catkin_make install won't work as expected. This PR makes the changes to make it work (and compile with newer versions of Gazebo too).

Signed-off-by: Emiliano Borghi <emiliano@smartmachine.nz>