### PR TITLE
modify published frame_id via sdf

### DIFF
--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -113,7 +113,10 @@ class LivoxPointsPlugin : public RayPlugin {
     int64_t maxPointSize = 1000;
     int64_t downSample = 1;
     uint16_t publishPointCloudType;
+    std::string frameName = "livox";
+
     bool visualize = false;
+
 
     double maxDist = 400.0;
     double minDist = 0.1;

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -61,8 +61,9 @@ void LivoxPointsPlugin::Load(gazebo::sensors::SensorPtr _parent, sdf::ElementPtr
     int argc = 0;
     char **argv = nullptr;
     auto curr_scan_topic = sdf->Get<std::string>("ros_topic");
+    frameName = sdf->Get<std::string>("frameName");
     ROS_INFO_STREAM("ros topic name:" << curr_scan_topic);
-
+    ROS_INFO_STREAM("ros frame id: "<<frameName);
     raySensor = _parent;
     auto sensor_pose = raySensor->Pose();
     SendRosTf(sensor_pose, raySensor->ParentName(), raySensor->Name());
@@ -348,7 +349,7 @@ void LivoxPointsPlugin::PublishPointCloud(std::vector<std::pair<int, AviaRotateI
 
     sensor_msgs::PointCloud scan_point;
     scan_point.header.stamp = ros::Time::now();
-    scan_point.header.frame_id = "livox";
+    scan_point.header.frame_id = frameName;
     auto &scan_points = scan_point.points;
     for (auto &pair : points_pair) {
         int verticle_index = roundf((pair.second.zenith - verticle_min) / verticle_incre);
@@ -444,7 +445,7 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
     pc.resize(pt_count);
     pcl::toROSMsg(pc, scan_point);
     scan_point.header.stamp = timestamp;
-    scan_point.header.frame_id = "livox";
+    scan_point.header.frame_id = frameName;
     rosPointPub.publish(scan_point);
     // SendRosTf(parentEntity->WorldPose(), world->Name(), raySensor->ParentName());
     ros::spinOnce();
@@ -507,7 +508,7 @@ void LivoxPointsPlugin::PublishPointCloud2XYZRTL(std::vector<std::pair<int, Avia
     }
     pcl::toROSMsg(pc, scan_point);
     scan_point.header.stamp = timestamp;
-    scan_point.header.frame_id = "livox";
+    scan_point.header.frame_id = frameName;
     rosPointPub.publish(scan_point);
     ros::spinOnce();
     if (scanPub && scanPub->HasConnections() && visualize) {
@@ -532,7 +533,7 @@ void LivoxPointsPlugin::PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int
     livox_ros_driver::CustomMsg msg;
     // msg.header.frame_id = raySensor->ParentName();
 
-    msg.header.frame_id = "livox";
+    msg.header.frame_id = frameName;
 
     struct timespec tn; 
     clock_gettime(CLOCK_REALTIME, &tn);


### PR DESCRIPTION
Define the frame_id of the published scan topic by adding an element in the SDF.